### PR TITLE
attempted connections to invalid hosts are now handled in Client and …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 *.py~
 
 textual.log
+
+*.log

--- a/networking/client.py
+++ b/networking/client.py
@@ -31,4 +31,5 @@ class Client:
         page_conn.send_request()
         #print("Receiving response")
         response = page_conn.receive_response()
+        page_conn.close_connection()
         return response

--- a/networking/errors.py
+++ b/networking/errors.py
@@ -1,0 +1,4 @@
+
+class InvalidHostError(Exception):
+    """Raised when socket cannot connect to host"""
+    pass

--- a/networking/log.py
+++ b/networking/log.py
@@ -1,0 +1,7 @@
+import logging
+logging.basicConfig(filename='networking.log', filemode='w', format='%(asctime)s:\n  %(name)s - %(levelname)s - %(message)s\n')
+
+
+
+netlog = logging.getLogger()
+netlog.setLevel(logging.DEBUG)


### PR DESCRIPTION
…view

If the host is valid but does not respond to client's request within 15 seconds, an exception is raised and the invalid host page is shown. 

Fixes #2

Created:
networking/errors.py
   - contains exceptions pertaining to critical errors, may contain more in the future
   - currently only contains InvalidHostError

Modified:
ui/view.py
   - Added exception handling in dispatch_search to listen for requests to invalid hosts (InvalidHostError)
      + displays `invalid_host_page` instead if exception occurs
   - Moved C-Q, C-S keybinds higher up in application priority
      + it didn't make sense for them to be lower in priority than keystrokes to the search bar
 
networking/connection.py
   - Added exception handling to constructor when connecting to specified host, handles socket level exceptions
      + If an exception is detected, `InvalidHostError` is raised
   - Added a timeout to `receive_response`, in case the server either doesn't want to talk to us, or is not setup for the gemini protocol