### PR TITLE
fixed link hovering, added more logging to widgets

### DIFF
--- a/networking/client.py
+++ b/networking/client.py
@@ -99,7 +99,7 @@ class Client:
             else:
                 parsed_lines.append((pl[0], pl[1]))
 
-                idx += 1
+            idx += 1
 
         #return raw_gem.decode().split("\n")
         #return ret_str

--- a/ui/view.py
+++ b/ui/view.py
@@ -76,6 +76,7 @@ class LagannView(App):
         elif key.key == "l":
             #TODO: Let Keys.ShiftL cycle backwards
             if not self.center_page.cycling:
+                self.log("Toggling link cycle")
                 self.center_page.toggle_cycle_links()
             else:
                 self.center_page.cycle_link()

--- a/ui/widgets/gem_page.py
+++ b/ui/widgets/gem_page.py
@@ -33,11 +33,11 @@ class GemPage(Widget):
 
 
     def _format_parsed_gem(self, gem_page):
-        self.log("parsed_gem: {}".format(gem_page))
+        #self.log("parsed_gem: {}".format(gem_page))
         pretty_page = Text("")
         idx = 0
-        hover_idx = self.link_indices[self.highlight_idx] if self.cycling else -1
-        #self.log("{} {} {}".format(self.cycling, self.highlight_idx, hover_idx))
+        hover_idx = self.get_highlighted()
+        self.log("Cycling?: {}\nLink #: {}\nLine number: {}".format(self.cycling, self.highlight_idx, hover_idx))
         for line in gem_page:
             if line[1] == 'h1':
                 pretty_page.append(line[0] + "\n", style = "bold bright_white")
@@ -87,13 +87,16 @@ class GemPage(Widget):
 
     def cycle_link(self) -> None:
         #self.log("IDX INCREMENTED {}({}) -> {}({})".format(self.highlight_idx, self.link_indices[old], self.highlight_idx, self.link_indices[new]))
-        self.highlight_idx = self.highlight_idx+1
+        self.highlight_idx = self.highlight_idx + 1
+        self.log("New idx: {}".format(self.highlight_idx))
+        self.log("Reset idx: {}".format(len(self.link_indices)))
         if self.highlight_idx == len(self.link_indices):
             self.highlight_idx = -1
             self.cycling = False
 
     def get_highlighted(self):
-        if(self.cycling):
+        if self.cycling:
+            self.log("Link Indices: {}".format(self.link_indices))
             return self.link_indices[self.highlight_idx]
         else:
             return -1
@@ -108,8 +111,8 @@ class GemPage(Widget):
             return self.body
 
     def render(self) -> Panel:
-        self.log(self.body)
+        #self.log(self.body)
         formatted_body = self._format_body()
-        self.log(self.log(formatted_body))
+        #self.log(self.log(formatted_body))
         return Panel(formatted_body,
                      box=box.MINIMAL)


### PR DESCRIPTION
It turns out that the reason the links weren't showing up right was because I didn't tab the incrementing out right in Client's `_parse_gmi` function. 
As it stood it was only being incremented when it got to a line that didn't actually have a link in it, which looked very strange when cycling through links in the app.
Fixes #7

Modified:
networking/client.py
   - Moved the idx incrementing outside the if/else statements in the for line in lines loop

ui/view.py, ui/widgets/gem_page.py
   - Added logging to more inner functions
