### PR TITLE
Relative links now work, tabs after link url formatting fixed

### DIFF
--- a/networking/client.py
+++ b/networking/client.py
@@ -59,9 +59,18 @@ class Client:
             return ("\n", "nl")
 
         if text_parts[0] == "=>":
-            text_parts = [x if '\t' not in x else x.split('\t') for x in text_parts]
+
+            if '\t' in text_parts[1]:
+                text_parts[1] = text_parts[1].split('\t')
+                text_parts[1] = [x for x in text_parts[1] if x != '']
+
+            netlog.debug(text_parts[1])
+
             if type(text_parts[1]) != str:
                 text_parts = [text_parts[0]] + text_parts[1] + text_parts[2:]
+
+            netlog.debug("text_parts: {}".format(text_parts))
+
             return ((text_parts[1], " ".join(text_parts[2:])), 'link')
 
         elif text_parts[0] == ">":

--- a/networking/lagcerts.py
+++ b/networking/lagcerts.py
@@ -47,7 +47,6 @@ def valid_cert(pem_cert, URL):
             return True
 
     else:
-        netlog.log("Matching fingerprint present for URL")
         return True
 
 def generate_client_cert():

--- a/ui/view.py
+++ b/ui/view.py
@@ -89,6 +89,9 @@ class LagannView(App):
             self.gem_page.scroll_to_center(highlight_idx)
         elif key.key == Keys.Enter and self.center_page.cycling:
             new_url = self.center_page.get_highlighted_link()
+            if not "gemini://" in new_url:
+                # It is a relative link, plop it onto the end of the URL in current_page
+                new_url = self.center_page.url + new_url
 
             await self.set_page(await self.dispatch_search(new_url), new_url)
             await self.search_bar.set_title(new_url)


### PR DESCRIPTION
Relative links now work as they should in the browser. LagannApp now takes the URL from the current `center_page` (really needs to be renamed), and appends the desired url to the end of it. 
It then passes this to the client through `get_page()`. 

There was a bug where links where not being formatted correctly due to multiple tabs being used to separate the URL the link leads to from the placeholder text. Such as `b"=> "gemini://google.com/\t\tThis is the placeholder text". 
This text would have been formatted as `" This is placeholder text"`, with an awkward space in the beginning. This was fixed by modifying the parsing rules in `_gmi_parse_line()` from networking/client.py 
Closes #11

Modified:
networking/client.py
   - Added better parsing rules for links, now takes into account multiple tabs after the desired link destination

networking/lagcerts.py
   - Removed a line of logging from `valid_cert()`, not really necessary to log that portion since that's the best case scenario

ui/view.py
   - View now appends the end of the desired URL to the current URL before passing it to the client, if it's a relative link.


