### PR TITLE
fixed a bug with relative parsing, and a bug with receiving a response

### DIFF
--- a/ui/view.py
+++ b/ui/view.py
@@ -34,7 +34,7 @@ from networking.client import DisplayForm
 
 app_client = Client()
 
-#Put LagannApp here, and make separate files for each widget
+# Put LagannApp here, and make separate files for each widget
 # have two views, one will be the gemini page and the other will
 # be the searchbar, when the user presses 's' the serachbar will come out
 # if they click away from the searchbar, it goes away.


### PR DESCRIPTION
Modified:
networking/client.py
   - fixed relative parsing in `_parse_query()`

networking/connection.py
   - Fixed bug when receiving server response,  
      + The response from the server isn't necessarily in two separate packets, they could be in one continuous packet where the header is separated from the body with `\r\n`.  The function was fixed to accommodate that case.